### PR TITLE
Partial implementation of python DB-API driver

### DIFF
--- a/cockroach/http_sender.py
+++ b/cockroach/http_sender.py
@@ -4,6 +4,7 @@ import requests
 
 from cockroach.util import RetryOptions, retry_with_backoff, RetryStatus
 from cockroach.sql.driver import wire_pb2
+from cockroach.sql.driver import errors
 
 # URL path prefix which accepts incoming HTTP requests for the SQL API.
 sql_endpoint = "/sql/Execute"
@@ -65,6 +66,9 @@ class HTTPSender(object):
                     # On a successful post, we're done with retry loop.
                     return RetryStatus.BREAK
         retry_with_backoff(http_retry_options, retryable)
+        for result in reply.results:
+            if result.error:
+                raise errors.DatabaseError(result.error)
         return reply
 
     def close(self):

--- a/cockroach/sql/driver/__init__.py
+++ b/cockroach/sql/driver/__init__.py
@@ -1,4 +1,4 @@
-from .connection import connect
+from .connection import *
 from .constants import *
 from .errors import *
 from .types import *

--- a/cockroach/sql/driver/__init__.py
+++ b/cockroach/sql/driver/__init__.py
@@ -1,0 +1,4 @@
+from .connection import connect
+from .constants import *
+from .errors import *
+from .types import *

--- a/cockroach/sql/driver/connection.py
+++ b/cockroach/sql/driver/connection.py
@@ -1,5 +1,72 @@
-import unittest
+from cockroach.http_sender import HTTPSender
+
+from .cursor import Cursor
+from . import errors
+from . import types
+from .wire_pb2 import Request
 
 
-def connect():
-    raise unittest.SkipTest('connect')
+class Connection(object):
+    def __init__(self, addr, user, database=None, auto_create=False):
+        self._sender = HTTPSender(addr)
+        self._user = user
+        self._database = database
+        self._closed = False
+        self._session = None
+
+        if self._database is not None:
+            if auto_create:
+                # TODO(bdarnell): create database doesn't take param?
+                self._send_request("CREATE DATABASE IF NOT EXISTS %s" %
+                                   self._database)
+            self._send_request("SET DATABASE = %(db)s", dict(db=self._database))
+
+    def close(self):
+        self._check_closed()
+        self._sender.close()
+        self._closed = True
+
+    def commit(self):
+        self._check_closed()
+
+    def rollback(self):
+        pass
+
+    def cursor(self):
+        return Cursor(self)
+
+    def _check_closed(self):
+        if self._closed:
+            raise errors.Error("connection is closed")
+
+    def _send_request(self, stmt, params=None):
+        self._check_closed()
+
+        req = Request(user=self._user)
+        if self._session is not None:
+            req.session = self._session
+        if params is not None:
+            # Transform the 'pyformat' query to our own '$1' placeholders.
+            param_map = {}
+            for key, in_param in sorted(params.items()):
+                req.params.extend([types._python_to_datum(in_param)])
+                param_map[key] = '$%d' % len(req.params)
+            stmt = stmt % param_map
+        req.sql = stmt
+
+        resp = self._sender.send(req)
+        self._session = resp.session
+        return resp
+
+
+# According to an "optional extension" of PEP 249 (which is enforced by the
+# compliance test), all error classes must also be available on the class
+# namespace.
+for e in errors.__all__:
+    setattr(Connection, e, getattr(errors, e))
+
+
+def connect(*args, **kwargs):
+    return Connection(*args, **kwargs)
+
+__all__ = ['Connection', 'connect']

--- a/cockroach/sql/driver/connection.py
+++ b/cockroach/sql/driver/connection.py
@@ -1,0 +1,5 @@
+import unittest
+
+
+def connect():
+    raise unittest.SkipTest('connect')

--- a/cockroach/sql/driver/constants.py
+++ b/cockroach/sql/driver/constants.py
@@ -3,4 +3,10 @@ apilevel = '2.0'
 # TODO(bdarnell): how thread-safe are we?
 threadsafety = 1
 
-paramstyle = 'numeric'
+# The DB-API has a complex scheme for allowing drivers to choose
+# which type of placeholders may be used. Unfortunately none of them
+# match our use of `$1`, and the only one we can implement without
+# client-side parsing of SQL is 'pyformat'.
+paramstyle = 'pyformat'
+
+__all__ = ['apilevel', 'threadsafety', 'paramstyle']

--- a/cockroach/sql/driver/constants.py
+++ b/cockroach/sql/driver/constants.py
@@ -1,0 +1,6 @@
+apilevel = '2.0'
+
+# TODO(bdarnell): how thread-safe are we?
+threadsafety = 1
+
+paramstyle = 'numeric'

--- a/cockroach/sql/driver/cursor.py
+++ b/cockroach/sql/driver/cursor.py
@@ -1,0 +1,96 @@
+import sys
+
+from . import errors
+from . import types
+from .wire_pb2 import Response
+
+
+class Cursor(object):
+    def __init__(self, conn):
+        self.conn = conn
+        self.arraysize = None
+        self._result = None
+        self._pos = None
+
+    @property
+    def rowcount(self):
+        if self._result is None:
+            return None
+        which = self._result.WhichOneof("union")
+        if which == "rows_affected":
+            return self._result.rows_affected
+        elif which == "rows":
+            return len(self._result.rows.rows)
+        elif which == "ddl":
+            return -1
+        else:
+            raise errors.InterfaceError("unsupported result type %s", which)
+
+    @property
+    def description(self):
+        if self._result is None:
+            return None
+        which = self._result.WhichOneof("union")
+        if which != "rows":
+            return None
+        cols = self._result.rows.columns
+        # Description tuples are (name, type_code, display_size,
+        # internal_size, precision, scale, null_ok); all but the first
+        # two are optional.
+        # TODO(bdarnell): return correct type when the server returns types.
+        return [(c, types.STRING, None, None, None, None, None) for c in cols]
+
+    def _send_request(self, stmt, params):
+        resp = self.conn._send_request(stmt, params)
+        if len(resp.results) != 1:
+            # TODO(bdarnell): we could support multi-result queries with
+            # the nextset() method.
+            raise errors.NotSupportedError("expected 1 result, got %s",
+                                           len(resp.results))
+        self._result = resp.results[0]
+        self._pos = 0
+
+    def execute(self, stmt, params=None):
+        self._send_request(stmt, params)
+
+    def executemany(self, stmt, seq_of_params):
+        total = 0
+        for params in seq_of_params:
+            self.execute(stmt, params)
+            rowcount = self.rowcount
+            if rowcount > 0:
+                total += rowcount
+        self._result = Response.Result(rows_affected=total)
+
+    def fetchone(self):
+        rows = self.fetchmany(1)
+        if len(rows) == 1:
+            return rows[0]
+        elif len(rows) == 0:
+            return None
+        else:
+            raise errors.DataError("expected 1 row, got %d" % len(rows))
+
+    def fetchmany(self, size=None):
+        if self._result is None or self._result.WhichOneof("union") != "rows":
+            raise errors.ProgrammingError("no results available")
+        if size is None:
+            size = self.arraysize or 1
+        # The double-slicing here is to avoid overflow when
+        # self._pos + size > sys.maxsize.
+        in_rows = self._result.rows.rows[self._pos:][:size]
+        self._pos += len(in_rows)
+        out_rows = []
+        for in_row in in_rows:
+            out_row = tuple(types._datum_to_python(d) for d in in_row.values)
+            out_rows.append(out_row)
+        return out_rows
+
+    def fetchall(self):
+        return self.fetchmany(sys.maxsize)
+
+    def setinputsizes(self, sizes):
+        pass
+
+    def setoutputsize(self, size, column=None):
+        pass

--- a/cockroach/sql/driver/errors.py
+++ b/cockroach/sql/driver/errors.py
@@ -1,0 +1,45 @@
+try:
+    from exceptions import StandardError
+except ImportError:
+    StandardError = Exception
+
+
+# This exception hierarchy is mandated by PEP 249.
+class Error(StandardError):
+    pass
+
+
+class Warning(StandardError):
+    pass
+
+
+class InterfaceError(Error):
+    pass
+
+
+class DatabaseError(Error):
+    pass
+
+
+class InternalError(DatabaseError):
+    pass
+
+
+class OperationalError(DatabaseError):
+    pass
+
+
+class ProgrammingError(DatabaseError):
+    pass
+
+
+class IntegrityError(DatabaseError):
+    pass
+
+
+class DataError(DatabaseError):
+    pass
+
+
+class NotSupportedError(DatabaseError):
+    pass

--- a/cockroach/sql/driver/errors.py
+++ b/cockroach/sql/driver/errors.py
@@ -43,3 +43,7 @@ class DataError(DatabaseError):
 
 class NotSupportedError(DatabaseError):
     pass
+
+__all__ = ['Error', 'Warning', 'InterfaceError', 'DatabaseError',
+           'InternalError', 'OperationalError', 'ProgrammingError',
+           'IntegrityError', 'DataError', 'NotSupportedError']

--- a/cockroach/sql/driver/test_dbapi.py
+++ b/cockroach/sql/driver/test_dbapi.py
@@ -1,4 +1,5 @@
 import dbapi20
+import time
 import unittest
 
 import cockroach.sql.driver
@@ -7,10 +8,30 @@ import cockroach.sql.driver
 class DBAPITest(dbapi20.DatabaseAPI20Test):
     def setUp(self):
         self.driver = cockroach.sql.driver
+        # Generate unique database names because the test doesn't
+        # always clean up after itself.
+        # TODO(bdarnell): improve cleanup so we don't need this.
+        database = time.strftime("test%y%m%d%H%M%S")
+        self.connect_kw_args = dict(addr="localhost:26257",
+                                    user="root",
+                                    database=database,
+                                    auto_create=True)
+        # Patch the table creation statements because we require primary keys.
+        self.ddl1 = self._patch_create_table(self.ddl1)
+        self.ddl2 = self._patch_create_table(self.ddl2)
         super(DBAPITest, self).setUp()
 
+    def _patch_create_table(self, ddl):
+        if ddl[-1] != ")":
+            raise Exception("Expected ddl to end in ')': %s", ddl)
+        return ddl[:-1] + ", primary key (name))"
+
+    # The following features are optional and we do not implement them.
+    # For some reason the test suite has placeholder tests for these
+    # features that just raise NotImplementedError, so we must override
+    # and disable them.
     def test_nextset(self):
-        raise unittest.SkipTest("TODO(bdarnell)")
+        raise unittest.SkipTest("nextset is not implemented")
 
     def test_setoutputsize(self):
-        raise unittest.SkipTest("TODO(bdarnell)")
+        raise unittest.SkipTest("setoutputsize is not implemented")

--- a/cockroach/sql/driver/test_dbapi.py
+++ b/cockroach/sql/driver/test_dbapi.py
@@ -1,0 +1,16 @@
+import dbapi20
+import unittest
+
+import cockroach.sql.driver
+
+
+class DBAPITest(dbapi20.DatabaseAPI20Test):
+    def setUp(self):
+        self.driver = cockroach.sql.driver
+        super(DBAPITest, self).setUp()
+
+    def test_nextset(self):
+        raise unittest.SkipTest("TODO(bdarnell)")
+
+    def test_setoutputsize(self):
+        raise unittest.SkipTest("TODO(bdarnell)")

--- a/cockroach/sql/driver/types.py
+++ b/cockroach/sql/driver/types.py
@@ -6,6 +6,10 @@ try:
 except ImportError:
     import enum34 as enum
 
+
+from .wire_pb2 import Datum
+
+
 class Binary(object):
     def __init__(self, v):
         self.v = v
@@ -45,3 +49,23 @@ class TypeCode(enum.Enum):
 
 for k, v in TypeCode.__members__.items():
     globals()[k] = v
+
+
+def _python_to_datum(val):
+    if isinstance(val, str):
+        return Datum(string_val=val)
+    else:
+        raise TypeError("unsupported type %s" % type(val))
+
+
+def _datum_to_python(datum):
+    which = datum.WhichOneof("payload")
+    if which is None:
+        return None
+    elif which == "string_val":
+        return datum.string_val
+    else:
+        raise TypeError("unsupported type %s" % which)
+
+__all__ = ['Binary', 'Date', 'Time', 'Timestamp', 'DateFromTicks', 'TimeFromTicks',
+           'TimestampFromTicks', 'STRING', 'BINARY', 'NUMBER', 'DATETIME', 'ROWID']

--- a/cockroach/sql/driver/types.py
+++ b/cockroach/sql/driver/types.py
@@ -1,0 +1,47 @@
+import datetime
+import time
+
+try:
+    import enum
+except ImportError:
+    import enum34 as enum
+
+class Binary(object):
+    def __init__(self, v):
+        self.v = v
+
+
+def Date(y, m, d):
+    return datetime.date(y, m, d)
+
+
+def Time(h, m, s):
+    return datetime.time(h, m, s)
+
+
+def Timestamp(y, mo, d, h, mi, s):
+    return datetime.datetime(y, mo, d, h, mi, s)
+
+
+# Implementations of the FromTicks methods are copied from PEP 249.
+def DateFromTicks(ticks):
+    return Date(*time.localtime(ticks)[:3])
+
+
+def TimeFromTicks(ticks):
+    return Time(*time.localtime(ticks)[3:6])
+
+
+def TimestampFromTicks(ticks):
+    return Timestamp(*time.localtime(ticks)[:6])
+
+
+class TypeCode(enum.Enum):
+    STRING = 1
+    BINARY = 2
+    NUMBER = 3
+    DATETIME = 4
+    ROWID = 5
+
+for k, v in TypeCode.__members__.items():
+    globals()[k] = v

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
     name='cockroach',
     packages=['cockroach', 'cockroach.sql.driver'],
     install_requires=install_requires,
-    extras_require={'tests': ['werkzeug']},
+    extras_require={'tests': ['werkzeug', 'dbapi-compliance']},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,4 @@ envlist = py27,py34,pypy,pypy3
 commands = python -m unittest {posargs:discover -b}
 # Manually install things from tests_require
 deps = werkzeug
+     dbapi-compliance


### PR DESCRIPTION
I've only implemented enough to get the `dbapi-compliance` test suite passing, which sadly isn't very comprehensive (no types but strings, no transactions).

This is a point of comparison for the PostgreSQL wire protocol work, to judge the difficulty of implementing custom drivers. I'm also working on a SQLAlchemy "dialect" plugin, which is representative of the work that would need to be done for various ORMs even if we speak an existing protocol. 